### PR TITLE
Fix error of fractures crossing image outline

### DIFF
--- a/morphomnist/perturb.py
+++ b/morphomnist/perturb.py
@@ -165,10 +165,12 @@ class Fracture(Perturbation):
     @staticmethod
     def _draw_line(img, p0, p1, brush):
         h, w = brush.shape
+        h_start, w_start = h // 2, w // 2
+        h_end, w_end = h - h_start, w - w_start
         ii, jj = draw.line(*p0, *p1)
         for i, j in zip(ii, jj):
             try:
-                img[i:i + h, j:j + w] &= brush
+                img[i - h_start:i + h_end, j - w_start:j + w_end] &= brush
             except ValueError:
                 # Rare case: Fracture would leave image outline, because
                 # selected point on skeleton is too close to image outline.

--- a/morphomnist/perturb.py
+++ b/morphomnist/perturb.py
@@ -167,4 +167,11 @@ class Fracture(Perturbation):
         h, w = brush.shape
         ii, jj = draw.line(*p0, *p1)
         for i, j in zip(ii, jj):
-            img[i:i + h, j:j + w] &= brush
+            try:
+                img[i:i + h, j:j + w] &= brush
+            except ValueError:
+                # Rare case: Fracture would leave image outline, because
+                # selected point on skeleton is too close to image outline.
+                # Ignore the fracture parts outside the image, but keep the
+                # parts within the image.
+                pass


### PR DESCRIPTION
When creating random fractures, it rarely happens that the fracture line would lea leave the image outline, because the selected point on the skeleton is too close to the image outline. This leads to a ValueError in Python. As this occurs very rarely,  just catching the error should be fine. When doing `perturb.Fracture(num_frac=3)` for every digit in the trainings set, it is likely that it happens about every 5 epochs on average. Because this solution catches the error inside the loop, it just ignores the fracture parts outside the image, but keep the parts of the fracture within the image. Since the brush is a disk, it could happen that the fracture is smaller at the pixels very close to the image outline. This should not matter, as it happens so rarely.