### PR TITLE
Add DSCM interventions

### DIFF
--- a/morphomnist/perturb.py
+++ b/morphomnist/perturb.py
@@ -2,7 +2,7 @@ import numpy as np
 from skimage import draw, morphology, transform
 
 from . import skeleton
-from .morpho import ImageMorphology
+from .morpho import ImageMoments, ImageMorphology, bounding_parallelogram
 
 
 class Perturbation:
@@ -177,3 +177,85 @@ class Fracture(Perturbation):
                 # Ignore the fracture parts outside the image, but keep the
                 # parts within the image.
                 pass
+
+
+def _get_disk(radius: int, scale: int) -> np.ndarray:
+    mag_radius = scale * radius
+    mag_disk = morphology.disk(mag_radius, dtype=np.float64)
+    disk = transform.pyramid_reduce(mag_disk, downscale=scale, order=1, channel_axis=None)
+    return disk  # type: ignore
+
+
+class SetThickness(Perturbation):
+    _disk_cache: dict[int, np.ndarray] = {}
+
+    def __init__(self, target_thickness: float):
+        self.target_thickness = target_thickness
+
+    def __call__(self, morph: ImageMorphology) -> np.ndarray:
+        delta = self.target_thickness - morph.mean_thickness
+        radius = int(morph.scale * abs(delta) / 2.)
+        if radius in self._disk_cache:
+            disk = self._disk_cache[radius]
+        else:
+            disk = _get_disk(radius, scale=16)
+            self._disk_cache[radius] = disk
+        img = morph.binary_image
+        if delta >= 0:
+            return morphology.dilation(img, disk)
+        else:
+            return morphology.erosion(img, disk)
+
+
+class LinearDeformation(Deformation):
+    def _get_matrix(self, moments: ImageMoments, morph: ImageMorphology) -> np.ndarray:
+        raise NotImplementedError
+
+    def warp(self, xy: np.ndarray, morph: ImageMorphology) -> np.ndarray:
+        moments = ImageMoments(morph.binary_image)
+        centroid = np.array(moments.centroid)
+        matrix = self._get_matrix(moments, morph)
+        xy_ = (xy - centroid) @ matrix.T + centroid
+        return xy_
+
+
+class SetSlant(LinearDeformation):
+    def __init__(self, target_slant_rad: float):
+        self.target_shear = -np.tan(target_slant_rad)
+
+    def _get_matrix(self, moments: ImageMoments, morph: ImageMorphology) -> np.ndarray:
+        source_shear = moments.horizontal_shear
+        delta = self.target_shear - source_shear
+        return np.array([[1., -delta], [0., 1.]])
+
+
+def _measure_width(morph: ImageMorphology, frac=.02, moments: ImageMoments | None = None) -> float:
+    top_left, top_right = bounding_parallelogram(morph.hires_image,
+                                                 frac=frac, moments=moments)[:2]
+    return (top_right[0] - top_left[0]) / morph.scale
+
+
+class SetWidth(LinearDeformation):
+    _tolerance = 1.
+
+    def __init__(self, target_width: float, validate=False):
+        self.target_width = target_width
+        self._validate = validate
+
+    def _get_matrix(self, moments: ImageMoments, morph: ImageMorphology) -> np.ndarray:
+        source_width = _measure_width(morph, moments=moments)
+        factor = source_width / self.target_width
+        shear = moments.horizontal_shear
+        return np.array([[factor, shear * (1. - factor)], [0., 1.]])
+
+    def __call__(self, morph: ImageMorphology) -> np.ndarray:
+        pert_hires_image = super().__call__(morph)
+        if self._validate:
+            pert_image = morph.downscale(pert_hires_image)
+            pert_morph = ImageMorphology(pert_image, threshold=morph.threshold, scale=morph.scale)
+            width = _measure_width(pert_morph)
+            if abs(width - self.target_width) > self._tolerance:
+                print(f"Incorrect width after transformation: {width:.1f}, "
+                      f"expected {self.target_width:.1f}.")
+                pert_hires_image = self(pert_morph)
+        return pert_hires_image

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
 
-from morphomnist.morpho import ImageMorphology
-from morphomnist.perturb import Deformation, Fracture, Perturbation, Swelling, Thickening, Thinning
+from morphomnist import perturb
+from morphomnist.measure import Morphometrics, measure_image
+from morphomnist.morpho import ImageMoments, ImageMorphology
 
 
 @pytest.fixture
@@ -12,24 +13,34 @@ def real_image() -> np.ndarray:
 
 @pytest.fixture
 def real_morphology(real_image: np.ndarray) -> ImageMorphology:
-    return ImageMorphology(real_image)
+    return ImageMorphology(real_image, scale=4)
 
 
-class MockDeformation(Deformation):
+class MockDeformation(perturb.Deformation):
     """Mock identity deformation to test the call to `skimage.transform.warp`."""
     def warp(self, xy: np.ndarray, morph: ImageMorphology) -> np.ndarray:
         return xy
 
 
+class MockLinearDeformation(perturb.LinearDeformation):
+    """Mock identity deformation to test the call to `Deformation.warp`."""
+    def _get_matrix(self, moments: ImageMoments, morph: ImageMorphology) -> np.ndarray:
+        return np.eye(2)
+
+
 @pytest.mark.parametrize("perturbation", [
-    Thinning(),
-    Thickening(),
-    Swelling(),
-    Fracture(),
+    perturb.Thinning(),
+    perturb.Thickening(),
+    perturb.Swelling(),
+    perturb.Fracture(),
+    perturb.SetThickness(4),
+    perturb.SetSlant(0.5),
+    perturb.SetWidth(10),
     MockDeformation(),
+    MockLinearDeformation(),
 ])
 def test_perturbation(
-    real_image: np.ndarray, real_morphology: ImageMorphology, perturbation: Perturbation
+    real_image: np.ndarray, real_morphology: ImageMorphology, perturbation: perturb.Perturbation
 ) -> None:
     perturbed_hires = perturbation(real_morphology)
     perturbed = real_morphology.downscale(perturbed_hires)
@@ -41,3 +52,28 @@ def test_perturbation(
     abs_diff = np.abs(perturbed - real_image).mean()
     rel_diff = abs_diff / real_image.ptp()
     assert rel_diff < 0.2
+
+
+def perturb_and_measure(real_morphology: ImageMorphology, perturbation: perturb.Perturbation) -> Morphometrics:
+    perturbed_hires = perturbation(real_morphology)
+    perturbed = real_morphology.downscale(perturbed_hires)
+    metrics = measure_image(perturbed)
+    return metrics
+
+
+def test_set_thickness(real_morphology: ImageMorphology) -> None:
+    target_thickness = 4
+    metrics = perturb_and_measure(real_morphology, perturb.SetThickness(target_thickness))
+    assert np.isclose(metrics.thickness, target_thickness, atol=0.2)
+
+
+def test_set_slant(real_morphology: ImageMorphology) -> None:
+    target_slant_rad = -0.5
+    metrics = perturb_and_measure(real_morphology, perturb.SetSlant(target_slant_rad))
+    assert np.isclose(metrics.slant, target_slant_rad, atol=0.01)
+
+
+def test_set_width(real_morphology: ImageMorphology) -> None:
+    target_width = 20
+    metrics = perturb_and_measure(real_morphology, perturb.SetWidth(target_width))
+    assert np.isclose(metrics.width, target_width, atol=1)


### PR DESCRIPTION
Includes the `SetThickness`, `SetSlant`, and `SetWidth` interventions, with corresponding tests. These were copied and updated from the [deep structural causal models (DSCMs)](https://github.com/biomedia-mira/deepscm/blob/master/deepscm/datasets/morphomnist/transforms.py) repository.